### PR TITLE
Change split with preg_split

### DIFF
--- a/src/WSSESoap.php
+++ b/src/WSSESoap.php
@@ -280,7 +280,7 @@ class WSSESoap
                     $tokenRef->appendChild($reference);
                     $x509 = openssl_x509_parse($objKey->getX509Certificate());
                     $keyid = $x509['extensions']['subjectKeyIdentifier'];
-                    $arkeyid = preg_split(':', $keyid);
+                    $arkeyid = preg_split('/:/', $keyid);
                     $data = '';
                     foreach ($arkeyid as $hexchar) {
                         $data .= chr(hexdec($hexchar));
@@ -345,7 +345,7 @@ class WSSESoap
                     $tokenRef->appendChild($reference);
                     $x509 = openssl_x509_parse($token->getX509Certificate());
                     $keyid = $x509['extensions']['subjectKeyIdentifier'];
-                    $arkeyid = preg_split(':', $keyid);
+                    $arkeyid = preg_split('/:/', $keyid);
                     $data = '';
                     foreach ($arkeyid as $hexchar) {
                         $data .= chr(hexdec($hexchar));

--- a/src/WSSESoap.php
+++ b/src/WSSESoap.php
@@ -280,7 +280,7 @@ class WSSESoap
                     $tokenRef->appendChild($reference);
                     $x509 = openssl_x509_parse($objKey->getX509Certificate());
                     $keyid = $x509['extensions']['subjectKeyIdentifier'];
-                    $arkeyid = preg_split('/:/', $keyid);
+                    $arkeyid = explode(':', $keyid);
                     $data = '';
                     foreach ($arkeyid as $hexchar) {
                         $data .= chr(hexdec($hexchar));
@@ -345,7 +345,7 @@ class WSSESoap
                     $tokenRef->appendChild($reference);
                     $x509 = openssl_x509_parse($token->getX509Certificate());
                     $keyid = $x509['extensions']['subjectKeyIdentifier'];
-                    $arkeyid = preg_split('/:/', $keyid);
+                    $arkeyid = explode(':', $keyid);
                     $data = '';
                     foreach ($arkeyid as $hexchar) {
                         $data .= chr(hexdec($hexchar));

--- a/src/WSSESoap.php
+++ b/src/WSSESoap.php
@@ -280,7 +280,7 @@ class WSSESoap
                     $tokenRef->appendChild($reference);
                     $x509 = openssl_x509_parse($objKey->getX509Certificate());
                     $keyid = $x509['extensions']['subjectKeyIdentifier'];
-                    $arkeyid = split(':', $keyid);
+                    $arkeyid = preg_split(':', $keyid);
                     $data = '';
                     foreach ($arkeyid as $hexchar) {
                         $data .= chr(hexdec($hexchar));
@@ -345,7 +345,7 @@ class WSSESoap
                     $tokenRef->appendChild($reference);
                     $x509 = openssl_x509_parse($token->getX509Certificate());
                     $keyid = $x509['extensions']['subjectKeyIdentifier'];
-                    $arkeyid = split(':', $keyid);
+                    $arkeyid = preg_split(':', $keyid);
                     $data = '';
                     foreach ($arkeyid as $hexchar) {
                         $data .= chr(hexdec($hexchar));


### PR DESCRIPTION
`split()` function was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0.

This causes following error: `Call to undefined function RobRichards\WsePhp\split()`

http://php.net/manual/en/function.split.php
http://php.net/manual/en/function.preg-split.php