### PR TITLE
Add private key passphrase option to decryptSoapDoc

### DIFF
--- a/src/WSSESoap.php
+++ b/src/WSSESoap.php
@@ -452,11 +452,13 @@ class WSSESoap
         $privKey = null;
         $privKey_isFile = false;
         $privKey_isCert = false;
+        $privKey_passphrase = '';
 
         if (is_array($options)) {
             $privKey = (!empty($options['keys']['private']['key']) ? $options['keys']['private']['key'] : null);
             $privKey_isFile = (!empty($options['keys']['private']['isFile']) ? true : false);
             $privKey_isCert = (!empty($options['keys']['private']['isCert']) ? true : false);
+            $privKey_passphrase = (!empty($options['keys']['private']['passphrase']) ? $options['keys']['private']['passphrase'] : '');
         }
 
         $objenc = new XMLSecEnc();
@@ -480,6 +482,7 @@ class WSSESoap
             XMLSecEnc::staticLocateKeyInfo($objKey, $node);
             if ($objKey && $objKey->isEncrypted) {
                 $objencKey = $objKey->encryptedCtx;
+                $objKey->passphrase = $privKey_passphrase;
                 $objKey->loadKey($privKey, $privKey_isFile, $privKey_isCert);
                 $key = $objencKey->decryptKey($objKey);
                 $objKey->loadKey($key);


### PR DESCRIPTION
Added an option to decryptSoapDoc named 'passphrase' so that an encrypted private key can be used to decrypt a document without manually decrypting the key beforehand.

Example:
```
$wsse = new WSSESoap($doc);
$options = [
    'keys' => [
        'private' => [
            'key' => $encryptedPrivateKey,
            'passphrase' => $privateKeyPass
        ]
    ]
];
$wsse->decryptSoapDoc($doc, $options);
```