### PR TITLE
Required at least 3.0.2 version of robrichards/xmlseclibs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     },
     "require": {
         "php": ">= 5.3",
-        "robrichards/xmlseclibs": ">=2.0"
+        "robrichards/xmlseclibs": ">=3.0.2"
     }
 }


### PR DESCRIPTION
older versions have of `robrichards/xmlseclibs` some security leaks