### PR TITLE
Change code to reflect comment

### DIFF
--- a/examples/soap-sign-encrypt.php
+++ b/examples/soap-sign-encrypt.php
@@ -19,7 +19,7 @@ class MySoap extends SoapClient
         $objWSSE = new WSSESoap($doc);
 
         /* add Timestamp with no expiration timestamp */
-        $objWSSE->addTimestamp();
+        $objWSSE->addTimestamp(null);
 
         /* create new XMLSec Key using AES256_CBC and type is private key */
         $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' => 'private'));

--- a/examples/soap-sign-encrypt.php
+++ b/examples/soap-sign-encrypt.php
@@ -11,7 +11,7 @@ define('SERVICE_CERT', 'sitekey_pub.cer');
 class MySoap extends SoapClient
 {
 
-    public function __doRequest($request, $location, $saction, $version)
+    public function __doRequest($request, $location, $saction, $version, $one_way = NULL)
     {
         $doc = new DOMDocument('1.0');
         $doc->loadXML($request);
@@ -46,7 +46,7 @@ class MySoap extends SoapClient
         $options = array("KeyInfo" => array("X509SubjectKeyIdentifier" => true));
         $objWSSE->encryptSoapDoc($siteKey, $objKey, $options);
 
-        $retVal = parent::__doRequest($objWSSE->saveXML(), $location, $saction, $version);
+        $retVal = parent::__doRequest($objWSSE->saveXML(), $location, $saction, $version, $one_way);
 
         $doc = new DOMDocument();
         $doc->loadXML($retVal);


### PR DESCRIPTION
WSSESoap::addTimestamp argument defaults to 3600 and results in the Expire tag being added, as opposed to what the comment above says. 
To prevent it from doing so just pass null as argument.