### PR TITLE
Add support for variable WSA NS in RelatesTo field.

### DIFF
--- a/src/WSASoap.php
+++ b/src/WSASoap.php
@@ -165,7 +165,7 @@ class WSASoap
     {
         $header = $this->locateHeader();
 
-        $nodeRelatesTo = $this->soapDoc->createElementNS(self::WSANS, self::WSAPFX . ':RelatesTo', $originalMessageId);
+        $nodeRelatesTo = $this->soapDoc->createElementNS($this->ns, self::WSAPFX . ':RelatesTo', $originalMessageId);
         $header->appendChild($nodeRelatesTo);
     }
 


### PR DESCRIPTION
Currently the addRelatesTo method creates an element in 2004 WSA namespace. Other methods like addReplyTo already use the $this->ns variable NS. Would be great if this is supported in addRelatesTo method too.