### PR TITLE
always return an ID with addMessageID

### DIFF
--- a/src/WSASoap.php
+++ b/src/WSASoap.php
@@ -140,6 +140,7 @@ class WSASoap
         $nodeID = $this->soapDoc->createElementNS($this->ns, self::WSAPFX.':MessageID', $id);
         $header->appendChild($nodeID);
         $this->messageID = $id;
+        return $id;
     }
 
     public function addReplyTo($address = null)


### PR DESCRIPTION
The function returns the stored ID if it is called again, but it does not return it on the first call. This should be made more consistent.